### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to this example project that uses nx and module federation to create a m
 
 - node.js (version 14 or higher)
 - bun (installed globally)
-- nx (installed globally)
+- nx (installed globally) @20.4.4
 
 ## installation
 
@@ -28,7 +28,7 @@ bun install
 Below are the steps taken to create this project from scratch:
 
 ```bash
-bunx create-nx-workspace --pm bun hagamos-un-microfront
+bunx create-nx-workspace@20.4.0 --pm bun hagamos-un-microfront
 ✔ Which stack do you want to use? · react
 ✔ What framework would you like to use? · none
 ✔ Integrated monorepo, or standalone project? · integrated


### PR DESCRIPTION
Adding specific version of the nx (@20.4.0) cli into the starting commands for correct replication of the project structure

Referring to  https://github.com/nrwl/nx/pull/30319 (probably added on 20.6.0)
https://nx.dev/nx-api/nx/documents/create-nx-workspace#options --useProjectJson flag is default to false when using workspace. Also, when running with @latest aks about using react router for server side components